### PR TITLE
feat: add `socketry debug` command for troubleshooting device access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# socketry
+
+## Coverage Badge
+
+When coverage changes, update the badge in README.md:
+- 90%+ → `brightgreen`, 80-89% → `green`, 70-79% → `yellowgreen`
+- 60-69% → `yellow`, 50-59% → `orange`, <50% → `red`
+
+Format: `![Coverage](https://img.shields.io/badge/coverage-XX%25-COLOR)`
+
+## Running Commands
+
+- Always use `uv run` to ensure the virtualenv is used
+- Examples: `uv run pytest`, `uv run mypy .`, `uv run python script.py`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # socketry
 
 [![CI](https://github.com/jlopez/socketry/actions/workflows/ci.yml/badge.svg)](https://github.com/jlopez/socketry/actions/workflows/ci.yml)
+![Coverage](https://img.shields.io/badge/coverage-22%25-red)
 ![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)
 
 Python API and CLI for controlling Jackery portable power stations.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -22,11 +22,29 @@ For status over the network, use `GET /device/property?deviceId={devId}` instead
 ## HTTP API
 
 **Base**: `https://iot.jackeryapp.com/v1`
-**Common headers**: `platform: 2`, `app_version: 1.2.0`, `token: {jwt}` (post-login)
+
+**Common headers** (from `AppApplication.u`):
+| Header | Value |
+|--------|-------|
+| `platform` | `2` |
+| `app_version` | `v1.0.7` (prefixed with `v`; from APK build config) |
+| `app_version_code` | `107` |
+| `Accept-Language` | `en` (or device locale) |
+| `sys_version` | e.g. `Android 14,level 34/[arm64-v8a]` |
+| `device_model` | e.g. `samsung/SM-G991B` |
+| `network` | `mobile` or `wifi` |
+| `token` | `{jwt}` (post-login) |
+
+**Important**: The server requires the full set of headers above for some endpoints.
+Notably, `GET /device/bind/list` returns error code 10600 if headers like `app_version_code`,
+`Accept-Language`, `sys_version`, `device_model`, or `network` are missing. Other endpoints
+(e.g. `/device/bind/shared`, `/device/property`) work with just `platform`, `app_version`,
+and `token`.
 
 **Note**: The app's HTTP client (`mh.k`) uses POST for all API calls. Fields on the API
 object are serialized as form-encoded body params. Endpoints with no request fields (like
-`device/bind/list` and `device/bind/shared`) also accept GET.
+`device/bind/list` and `device/bind/shared`) accept GET but **not** POST — POST returns
+error 10600 for parameterless endpoints.
 
 ### Login: `POST /auth/login`
 

--- a/src/socketry/_constants.py
+++ b/src/socketry/_constants.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import platform
 from pathlib import Path
 
 API_BASE = "https://iot.jackeryapp.com/v1"
@@ -45,8 +46,16 @@ UJLtYvgsxiBKAnK8YkAyu51Jm8uLz1BZ1RANf22vv0QUTW+SGdgc5Q1h610G9N1i
 CRED_DIR = Path.home() / ".config" / "socketry"
 CRED_FILE = CRED_DIR / "credentials.json"
 
+# The server requires Android-style headers for some endpoints (notably
+# /device/bind/list returns error 10600 without them).  Values match the
+# decompiled APK v1.0.7 request interceptor (AppApplication.u).
 APP_HEADERS: dict[str, str] = {
     "platform": "2",
-    "app_version": "1.2.0",
+    "app_version": "v1.0.7",
+    "app_version_code": "107",
+    "Accept-Language": "en",
+    "sys_version": f"Python {platform.python_version()}",
+    "device_model": f"{platform.system()}/{platform.machine()}",
+    "network": "wifi",
     "Content-Type": "application/x-www-form-urlencoded",
 }


### PR DESCRIPTION
Tests both GET and POST for /device/bind/list and /device/bind/shared
to diagnose device access issues, and dumps /device/property for the
first cached device.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
