### PR TITLE
feat(mqtt): replace paho-mqtt with aiomqtt for async MQTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socketry
 
 [![CI](https://github.com/jlopez/socketry/actions/workflows/ci.yml/badge.svg)](https://github.com/jlopez/socketry/actions/workflows/ci.yml)
-![Coverage](https://img.shields.io/badge/coverage-44%25-orange)
+![Coverage](https://img.shields.io/badge/coverage-59%25-orange)
 ![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)
 
 Python API and CLI for controlling Jackery portable power stations.
@@ -176,8 +176,8 @@ async def main():
     print(f"{setting.name}: {setting.format_value(value)}")
 
     # Control
-    client.set_property("ac", "on")
-    result = client.set_property("light", "high", wait=True)
+    await client.set_property("ac", "on")
+    result = await client.set_property("light", "high", wait=True)
 
 asyncio.run(main())
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.11"
 license = "MIT"
 dependencies = [
     "typer>=0.9",
-    "paho-mqtt>=2.0",
+    "aiomqtt>=2.0",
     "aiohttp>=3.9",
     "pycryptodome>=3.19",
 ]

--- a/src/socketry/cli.py
+++ b/src/socketry/cli.py
@@ -326,7 +326,7 @@ def set_setting(
     typer.echo(f"Setting {s.slug} to {value}...")
 
     try:
-        result = client.set_property(setting, value, wait=wait, verbose=verbose)
+        result = asyncio.run(client.set_property(setting, value, wait=wait, verbose=verbose))
     except (KeyError, ValueError) as e:
         typer.echo(str(e), err=True)
         raise typer.Exit(1) from None

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aiomqtt"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "paho-mqtt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/b5/798e4855d17f0f3a2e2ed21c07473fcb4bb45993116693d0f68553927e2c/aiomqtt-2.5.0.tar.gz", hash = "sha256:70e181c140a54ae736394efe2b9e865f665551a5417f6957456cc46010487b21", size = 86453, upload-time = "2026-01-04T16:46:51.079Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/24/1d5d7d89906db1a94b5029942c2fd909cf8e8551b288f56c03053d5615f8/aiomqtt-2.5.0-py3-none-any.whl", hash = "sha256:65dabeafeeee7b88864361ae9a118d81bd27082093f32f670a5c5fab17de8cf2", size = 15983, upload-time = "2026-01-04T16:46:49.736Z" },
+]
+
+[[package]]
 name = "aioresponses"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1055,11 +1067,11 @@ wheels = [
 
 [[package]]
 name = "socketry"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },
-    { name = "paho-mqtt" },
+    { name = "aiomqtt" },
     { name = "pycryptodome" },
     { name = "typer" },
 ]
@@ -1078,7 +1090,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9" },
-    { name = "paho-mqtt", specifier = ">=2.0" },
+    { name = "aiomqtt", specifier = ">=2.0" },
     { name = "pycryptodome", specifier = ">=3.19" },
     { name = "typer", specifier = ">=0.9" },
 ]


### PR DESCRIPTION
## Summary

- Replace synchronous `paho-mqtt` with `aiomqtt` for native async MQTT support
- Rewrite MQTT helpers (~140 lines → ~60 lines) using `aiomqtt`'s async context manager and message iterator
- Eliminate temp file TLS cert handling in favor of in-memory `ssl.SSLContext` (`cadata=`)
- Convert `Client.set_property()` to async, update CLI to use `asyncio.run()`
- Add 26 new MQTT tests (TLS, params, publish, subscribe+wait, filtering, timeout)
- Coverage: 44% → 59%

Fixes #7

## Test plan

- [x] `uv run ruff check src/ tests/` passes
- [x] `uv run mypy .` passes
- [x] `uv run pytest` — 82 tests pass
- [x] Manual: `socketry set light low/high/sos` (fire-and-forget)
- [x] Manual: `socketry set light high --wait` (subscribe+wait path)
- [x] Manual: `socketry get light` confirms device received commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)