### PR TITLE
feat(client): add Device class and shared MQTT connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socketry
 
 [![CI](https://github.com/jlopez/socketry/actions/workflows/ci.yml/badge.svg)](https://github.com/jlopez/socketry/actions/workflows/ci.yml)
-![Coverage](https://img.shields.io/badge/coverage-68%25-yellow)
+![Coverage](https://img.shields.io/badge/coverage-72%25-yellowgreen)
 ![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)
 
 Python API and CLI for controlling Jackery portable power stations.

--- a/src/socketry/__init__.py
+++ b/src/socketry/__init__.py
@@ -1,6 +1,6 @@
 """Python API and CLI for controlling Jackery portable power stations."""
 
-from socketry.client import Client, Subscription
+from socketry.client import Client, Device, Subscription
 from socketry.properties import MODEL_NAMES, PROPERTIES, Setting
 
-__all__ = ["Client", "MODEL_NAMES", "PROPERTIES", "Setting", "Subscription"]
+__all__ = ["Client", "Device", "MODEL_NAMES", "PROPERTIES", "Setting", "Subscription"]


### PR DESCRIPTION
Introduces `Device` objects for per-device operations without the
single-device selection pattern, enabling clean multi-device use by
the Home Assistant integration.

## New API

```python
device = client.device(0)          # by index
device = client.device("SN001")    # by serial number

props = await device.get_all_properties()
await device.set_property("ac", "on")
await device.set_property("ac", "on", wait=True)
```

## Shared MQTT connection

`_run_subscribe_loop` now sets `Client._active_mqtt` while connected.
`_publish_command` and `_publish_and_wait` publish through the active
connection when available, avoiding the broker kick-off that occurred
when a short-lived command connection evicted the subscription.

Pending one-shot responses (`_publish_and_wait`) are registered as
`(predicate, Future)` pairs and resolved by the subscribe loop as
messages arrive — no second connection needed.

## Fix for set --wait returning wrong property

`_publish_and_wait` now accepts `expected_keys` and only accepts a
`DevicePropertyChange` response that contains at least one of the
commanded property keys. Unrelated periodic status updates (battery
temp, output power, etc.) are skipped.

Fixes: #10, #14

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
