### PR TITLE
feat(client): implement token auto-refresh via re-authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # socketry
 
 [![CI](https://github.com/jlopez/socketry/actions/workflows/ci.yml/badge.svg)](https://github.com/jlopez/socketry/actions/workflows/ci.yml)
-![Coverage](https://img.shields.io/badge/coverage-72%25-yellowgreen)
+![Coverage](https://img.shields.io/badge/coverage-74%25-yellowgreen)
 ![Python](https://img.shields.io/badge/python-3.11%20%7C%203.12%20%7C%203.13-blue)
 
 Python API and CLI for controlling Jackery portable power stations.


### PR DESCRIPTION
## Summary

Implements transparent token refresh so the client keeps working after the ~30-day JWT expiry (fixes #9).

- **Proactive refresh**: JWT `exp` claim is decoded on login and stored as `tokenExp` in credentials. Before each HTTP call, `_ensure_fresh_token()` checks if the token expires within 1 hour and re-authenticates if so. A `Lock` prevents concurrent refreshes from triggering multiple logins.
- **Reactive fallback**: `_fetch_device_properties` and `_fetch_all_devices` raise `TokenExpiredError` on API code `10402`. Public methods catch it, force a re-login, and retry the call once.
- **Credential storage**: Password is now persisted in `credentials.json` (already `chmod 0o600`) so re-login can happen without user interaction.
- **MQTT**: `_run_subscribe_loop` calls `_ensure_fresh_token()` before each connection attempt and re-reads MQTT params per iteration so reconnects use fresh credentials.
- **`_http_login(fetch_devices=False)`**: Skip the device-list fetch during token refresh to avoid redundant API calls.

## Test plan

- [ ] 27 new unit tests covering `_decode_jwt_exp`, `_ensure_fresh_token` (no-op when fresh, refresh when near expiry, refresh when `tokenExp` is None, no-op without password, concurrent calls trigger exactly one re-login), `TokenExpiredError` propagation from `_fetch_*` helpers, and reactive retry on 10402 for all three public HTTP methods
- [ ] All 146 tests pass, ruff + mypy clean
- [ ] Manual test: run `uv run socketry get` after token expiry (or set `tokenExp=0` in credentials.json to force a proactive refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)