### PR TITLE
feat(client): wrap MqttError; use KeyError consistently in device() SN lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ htmlcov/
 # Keep these
 !.env.example
 !.gitignore
+artifacts/

--- a/src/socketry/__init__.py
+++ b/src/socketry/__init__.py
@@ -1,6 +1,6 @@
 """Python API and CLI for controlling Jackery portable power stations."""
 
-from socketry.client import Client, Device, Subscription
+from socketry.client import Client, Device, MqttError, Subscription
 from socketry.properties import MODEL_NAMES, PROPERTIES, Setting
 
-__all__ = ["Client", "Device", "MODEL_NAMES", "PROPERTIES", "Setting", "Subscription"]
+__all__ = ["Client", "Device", "MODEL_NAMES", "MqttError", "PROPERTIES", "Setting", "Subscription"]

--- a/uv.lock
+++ b/uv.lock
@@ -1067,7 +1067,7 @@ wheels = [
 
 [[package]]
 name = "socketry"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
- Add socketry.MqttError (ConnectionError subclass) to replace leaking
  aiomqtt.MqttError from Client.set_property and Device.set_property
- device() with a string SN now raises KeyError (not IndexError) when
  the device list is empty, matching the behaviour for a missing SN

Fixes: #21

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
