### PR TITLE
feat(client): add is_connected property to Subscription

### DIFF
--- a/src/socketry/client.py
+++ b/src/socketry/client.py
@@ -463,7 +463,7 @@ class Client:
         method cancels the background listener.
         """
         task = asyncio.create_task(self._run_subscribe_loop(callback, on_disconnect=on_disconnect))
-        return Subscription(task)
+        return Subscription(task, self)
 
     # ------------------------------------------------------------------
     # Control (MQTT)
@@ -672,8 +672,14 @@ class Subscription:
     subscription ends (e.g. via cancellation or error).
     """
 
-    def __init__(self, task: asyncio.Task[None]) -> None:
+    def __init__(self, task: asyncio.Task[None], client: Client) -> None:
         self._task = task
+        self._client = client
+
+    @property
+    def is_connected(self) -> bool:
+        """True when the MQTT broker connection is currently established."""
+        return self._client._active_mqtt is not None
 
     async def stop(self) -> None:
         """Cancel the subscription and wait for cleanup."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,8 +50,9 @@ def _make_subscribe_mock(
             for sn, props in messages:
                 await callback(sn, props)
 
-        task = asyncio.get_event_loop().create_task(run())
-        return Subscription(task)
+        task = asyncio.create_task(run())
+        dummy_client = Client(MOCK_CREDS)
+        return Subscription(task, dummy_client)
 
     return AsyncMock(side_effect=fake_subscribe)
 


### PR DESCRIPTION
Adds a read-only `is_connected: bool` property to `Subscription` that
returns `True` when the MQTT broker connection is currently established
(i.e., `Client._active_mqtt is not None`).

`Subscription.__init__` now takes a `client` parameter so it can
inspect the client's live connection state at any time. Updated all
call sites in `Client.subscribe`, `tests/test_client.py`, and
`tests/test_cli.py` accordingly.

Fixes: #22

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
