### PR TITLE
fix(ci): use PAT for release-please to trigger CI on its PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,31 +3,25 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.pre-commit-config.yaml'
+      - '.github/workflows/ci.yml'
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      code: ${{ steps.filter.outputs.code }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            code:
-              - 'src/**/*.py'
-              - 'tests/**/*.py'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - '.pre-commit-config.yaml'
-              - '.github/workflows/ci.yml'
-
   lint:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,8 +37,6 @@ jobs:
         run: uv run pre-commit run --all-files
 
   test:
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   pypi-publish:
     needs: release-please


### PR DESCRIPTION
Release Please PRs were stuck with "waiting for status to be reported"
because GITHUB_TOKEN-triggered events don't start other workflows.
Use a fine-grained PAT (RELEASE_PLEASE_TOKEN) so CI runs on RP PRs.

Also reverts the earlier dorny/paths-filter experiment in ci.yml,
restoring the simpler workflow-level paths filter.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
