### PR TITLE
fix(client): raise AuthenticationError instead of RuntimeError on login failure

### DIFF
--- a/src/socketry/client.py
+++ b/src/socketry/client.py
@@ -854,7 +854,7 @@ async def _http_login(
 
         if body.get("code") != 0:
             msg = body.get("msg", "unknown error")
-            raise RuntimeError(f"Login failed: {msg}")
+            raise AuthenticationError(f"Login failed: {msg}")
 
         data = body["data"]
         token = body["token"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -290,7 +290,7 @@ class TestHttpLogin:
     async def test_login_failure_code(self):
         with aioresponses() as m:
             m.post(_LOGIN_URL, payload={"code": 1, "msg": "Bad credentials"})
-            with pytest.raises(RuntimeError, match="Login failed: Bad credentials"):
+            with pytest.raises(AuthenticationError, match="Login failed: Bad credentials"):
                 await _http_login("bad@example.com", "wrong")
 
     async def test_login_http_error(self):


### PR DESCRIPTION
`_http_login()` now raises `AuthenticationError` (like `_relogin()` does)
so consumers can catch a single typed exception for all credential failures.

Fixes: #32
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
