### PR TITLE
fix(ci): update uv.lock on release-please PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,25 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
+      - uses: actions/checkout@v4
+        if: steps.release.outputs.pr != ''
+        with:
+          ref: release-please--branches--main--components--socketry
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
+      - uses: astral-sh/setup-uv@v5
+        if: steps.release.outputs.pr != ''
+
+      - name: Update uv.lock for version bump
+        if: steps.release.outputs.pr != ''
+        run: |
+          uv lock --upgrade-package socketry
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add uv.lock
+          git diff --staged --quiet || git commit -m "chore: update uv.lock for version bump"
+          git push
+
   pypi-publish:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true'


### PR DESCRIPTION
Workaround for googleapis/release-please#2561: after release-please
creates or updates a release PR, check out the PR branch and run
`uv lock --upgrade-package socketry` to keep uv.lock in sync with
the version bump in pyproject.toml.

Will be reverted once the native fix lands (see #37).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
